### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Set permissions via `chmod -R a+rw temp log www/data`
 
 See [how to contribute](https://contributte.org/contributing.html) to this package.
 
-This package is currently maintaining by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">


### PR DESCRIPTION
This PR finalizes the archive style for this repository by updating the Development section to past tense.

## Changes
- Changed "This package is currently maintaining by these authors" to "This package was maintained by these authors"

## Notes
- Repository was already archived, so I unarchived it temporarily to make these changes
- Repository can be re-archived after this PR is merged if desired
- README already had the deprecation badge and disclaimer in place

The README now fully follows the archive template from `.ai/archive-repo.md` (Option C for website/site projects).